### PR TITLE
Add support for NOTIFYCMD and fix Jinja2 syntax.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,3 +50,8 @@ nut_upsmon_extra: |
   RBWARNTIME 43200
   NOCOMMWARNTIME 300
   FINALDELAY 5
+
+# when set NOTIFYCMD will be configured to this path
+# nut_upsmon_notifycmd:
+# when set, the content will be copied to the nut_upsmon_notifycmd path
+# nut_upsmon_notifycmd_content:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,8 @@
 
 - name: Ensure NUT packages are installed.
   package:
-    name: "{{ item }}"
+    name: "{{ nut_packages }}"
     state: present
-  with_items: "{{ nut_packages }}"
 
 - name: Install NUT configuration files.
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,3 +35,4 @@
     owner: root
     group: nut
     mode: 0770
+  when: nut_upsmon_notifycmd_content is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,3 +28,11 @@
     - upsd.conf
     - upsmon.conf
   notify: restart nut
+
+- name: Install custom notifycmd script.
+  copy:
+    dest: "{{ nut_upsmon_notifycmd }}"
+    content: "{{ nut_upsmon_notifycmd_content }}"
+    owner: root
+    group: nut
+    mode: 0770

--- a/templates/ups.conf.j2
+++ b/templates/ups.conf.j2
@@ -5,7 +5,7 @@
     driver = {{ ups.driver }}
     port   = {{ ups.device }}
     desc   = "{{ ups.description }}"
-    {% extra|indent(4) %}
+    {{ ups.extra | default('') | indent(4) }}
 {% endfor %}
 
 {% nut_ups_extra %}

--- a/templates/ups.conf.j2
+++ b/templates/ups.conf.j2
@@ -8,4 +8,4 @@
     {{ ups.extra | default('') | indent(4) }}
 {% endfor %}
 
-{% nut_ups_extra %}
+{{ nut_ups_extra }}

--- a/templates/upsd.conf.j2
+++ b/templates/upsd.conf.j2
@@ -1,3 +1,3 @@
 # {{ ansible_managed }}
 
-{% nut_upsd_extra %}
+{{ nut_upsd_extra }}

--- a/templates/upsmon.conf.j2
+++ b/templates/upsmon.conf.j2
@@ -4,4 +4,8 @@
 MONITOR {{ ups.name }}@{{ nut_host }} 1 {{ nut_user }} {{ nut_password }} master
 {% endfor %}
 
-{% nut_upsmon_extra %}
+{% if nut_upsmon_notifycmd %}
+NOTIFYCMD {{ nut_upsmon_notifycmd }}
+{% endif %}
+
+{{ nut_upsmon_extra }}


### PR DESCRIPTION
Hi @ntd!

Thanks for the role!
I had some problems using the latest changes from your dev branch with Ansible 2.7.
I fixed the issues on my fork and perhaps you want to integrate this into your role.

1. Jinja2 syntax.

Ansible complained for example about `{% nut_ups_extra %}` and it did not work.
It is the first time I stumpbled this kind of syntax for rendering a value in a template. Is this working on your side? I changed the syntax to `{{ VARIABLE }}`.

2. Add support for `NOTIFYCMD`

You can either only specify a path to an existing script (`nut_upsmon_notifycmd`), or use `nut_upsmon_notifycmd_content` to place a script in the path specified by the `nut_upsmon_notifycmd` property.

3. Use list based package installation

In the more recent versions of Ansible it is possible (and recommended) to use the list based installation feature of packages. Package installation using `with_items` takes more time and produces more log output.

Feedback is appreciated :)