### PR TITLE
Handle driver service names

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,4 @@
 ---
 - name: restart nut
-  service:
-    name: "{{ item }}"
-    state: restarted
-  with_items: "{{ nut_services }}"
+  ansible.builtin.include_tasks: "../tasks/restart.yml"
   when: nut_enable_service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,50 +1,50 @@
 ---
 
-- name: Include OS-specific variables.
+- name: "Include OS-specific variables."
   include_vars: "{{ ansible_os_family }}.yml"
 
-- name: Define nut_packages.
+- name: "Define nut_packages."
   set_fact:
     nut_packages: "{{ __nut_packages | list }}"
   when: nut_packages is not defined
 
-- name: Ensure NUT packages are installed.
+- name: "Ensure NUT packages are installed."
   package:
     name: "{{ nut_packages }}"
     state: present
 
-- name: Define configuration files.
+- name: "Define configuration files."
   set_fact:
     nut_configuration_files:
       - nut.conf
       - upsmon.conf
 
-- name: Add ups.conf to configuration files.
+- name: "Add ups.conf to configuration files."
   set_fact:
     nut_configuration_files: "{{ nut_configuration_files + ['ups.conf'] }}"
   when: '("nut-server" in nut_services) or ("nut-driver" in nut_services)'
 
-- name: Add upsd.users and upsd.conf to configuration files.
+- name: "Add upsd.users and upsd.conf to configuration files."
   set_fact:
     nut_configuration_files: "{{ nut_configuration_files + ['upsd.users', 'upsd.conf'] }}"
   when: '"nut-server" in nut_services'
 
-- name: Install NUT configuration files.
+- name: "Install NUT configuration files."
   template:
     src: "{{ item }}.j2"
-    dest: "{{__nut_config_dir}}{{ item }}"
-    owner: root
-    group: nut
-    mode: 0640
+    dest: "{{ __nut_config_dir }}{{ item }}"
+    owner: "root"
+    group: "nut"
+    mode: "0640"
   with_items: "{{ nut_configuration_files }}"
-  notify: restart nut
-  when: nut_managed_config
+  notify: "restart nut"
+  when: "nut_managed_config"
 
 - name: Install custom notifycmd script.
   copy:
     dest: "{{ nut_upsmon_notifycmd }}"
     content: "{{ nut_upsmon_notifycmd_content }}"
-    owner: root
-    group: nut
-    mode: 0770
-  when: nut_upsmon_notifycmd_content is defined
+    owner: "root"
+    group: "nut"
+    mode: "0770"
+  when: "nut_upsmon_notifycmd_content is defined"

--- a/tasks/restart.yml
+++ b/tasks/restart.yml
@@ -1,0 +1,38 @@
+---
+- name: "Populate service facts."
+  ansible.builtin.service_facts:
+  when: "'nut-driver' in nut_services"
+
+- name: "Populate initial nut facts."
+  ansible.builtin.set_fact:
+    nut_driver_services: []
+    nut_other_services: "{{ nut_services }}"
+
+- name: "Append per-device nut-driver services."
+  ansible.builtin.set_fact:
+    nut_driver_services: "{{ nut_driver_services + [service_name] if service_name in ansible_facts.services else nut_driver_services }}"
+  vars:
+    name: "{{ item.name }}"
+    service_name: "nut-driver@{{ item.name }}.service"
+  loop: "{{ nut_ups }}"
+  when: "'services' in ansible_facts"
+
+- name: "Restart named nut-driver services."
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "{{ nut_driver_services }}"
+  when: "nut_driver_services | length > 0"
+
+- name: "Exclude bare nut-driver service from list to restart"
+  ansible.builtin.set_fact:
+    nut_other_services: "{{ nut_other_services - ['nut-driver'] }}"
+  with_items: "{{ nut_driver_services }}"
+  when: "nut_driver_services | length > 0"
+
+- name: "Restart nut."
+  ansible.builtin.service:
+    name: "{{ item }}"
+    state: restarted
+  with_items: "{{ nut_other_services }}"
+  when: nut_enable_service


### PR DESCRIPTION
This might be considered a slightly gross setup, but I was not sure how else to do this transformation. We check to see if nut-driver@NAME.service is a service, and if so, we add it to a list, for each UPS name. If that list has anything in it, we drop nut-driver from the list of hardcoded services we are going to restart. Then we restart that list as well as the driver-named list.