### PR TITLE
fix: substracting lists is not supported in recent ansible versions

### DIFF
--- a/tasks/restart.yml
+++ b/tasks/restart.yml
@@ -26,7 +26,7 @@
 
 - name: "Exclude bare nut-driver service from list to restart"
   ansible.builtin.set_fact:
-    nut_other_services: "{{ nut_other_services - ['nut-driver'] }}"
+    nut_other_services: "{{ nut_other_services | difference(['nut-driver']) }}"
   with_items: "{{ nut_driver_services }}"
   when: "nut_driver_services | length > 0"
 


### PR DESCRIPTION
And another one. Recent ansible versions will not allow to use the minus operator between two lists. This PR uses the build in [difference filter](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/difference_filter.html) to circumvent that issue.